### PR TITLE
CI: Check the Deadlinks

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,7 +2,7 @@ name: Markdown lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     types: [assigned, opened, synchronize, reopened]
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,17 @@
+name: Markdown lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'restqa-404-links'
+      uses: restqa/404-links@3.1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi 👋,
After checking some project on the list i realized that a few of the links are dead.
Then i'm proposing to add a github action that would allow to check if some link are dead.

As of now the github action is triggered by push event but we could update it to have it triggered periodically.

Next step: Enable github action on the repo if it hasn't been activated yet.