### PR TITLE
Add SpatialReal — Real-time avatar rendering SDK for voice AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Conference or Journal Year. [[PDF](link)] [[Project](link)] [[Code](link)] [[Dat
 
 </p></details><p></p>
 
+## Industry Demo or Product
+
+**SpatialReal — Real-time Lip-Synced Avatar Rendering for Voice AI Agents.**<br>
+*SpatialReal Team.*<br>
+2025. [[Website](https://spatialreal.ai/)] [[Docs](https://docs.spatialreal.ai/overview/introduction)] [[LiveKit Plugin](https://github.com/spatialwalk/livekit-plugins-spatialreal)]
+
+Real-time lip-synced avatar rendering SDK for voice AI agents. Integrates with LiveKit voice agents via `pip install livekit-plugins-spatialreal`. Sub-1.5s latency, 10-20 KB/s bandwidth (vs 1-2 MB/s for cloud rendering), free avatar library, MIT licensed.
+
 ## 3D/4D Human Avatar Generation and Animation
 
 **Generative Human Geometry Distribution.**<br>


### PR DESCRIPTION
## Adding SpatialReal to Industry Demo or Product

**SpatialReal** is a real-time lip-synced avatar rendering SDK for voice AI agents. It integrates with LiveKit voice agents via `pip install livekit-plugins-spatialreal`.

**Why this belongs:**
- Sub-1.5s latency with 10-20 KB/s bandwidth (vs 1-2 MB/s for cloud rendering)
- Free avatar library, MIT licensed
- LiveKit-native integration — fits the voice agent ecosystem
- Already has a live plugin for LiveKit agents

**Links:**
- Website: https://spatialreal.ai/
- Docs: https://docs.spatialreal.ai/overview/introduction
- Plugin: https://github.com/spatialwalk/livekit-plugins-spatialreal

*Submitted as part of the Industry Demo or Product section for real-time avatar solutions.*